### PR TITLE
Add gamepad button support to LKey input system

### DIFF
--- a/Essentials/Components/LKeyInputAcquirer.cs
+++ b/Essentials/Components/LKeyInputAcquirer.cs
@@ -1,6 +1,7 @@
 using Starlight.Enums;
 using Starlight.Storage;
 using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
 
 namespace Starlight.Components;
 
@@ -11,6 +12,26 @@ internal class LKeyInputAcquirer : MonoBehaviour
     private HashSet<LKey> pressedKeys = new HashSet<LKey>();
     private HashSet<LKey> downThisFrame = new HashSet<LKey>();
     private HashSet<LKey> upThisFrame = new HashSet<LKey>();
+
+    private static readonly (System.Func<Gamepad, ButtonControl> control, LKey key)[] GamepadBindings =
+    {
+        (g => g.buttonSouth,        LKey.GamepadSouth),
+        (g => g.buttonNorth,        LKey.GamepadNorth),
+        (g => g.buttonEast,         LKey.GamepadEast),
+        (g => g.buttonWest,         LKey.GamepadWest),
+        (g => g.leftShoulder,       LKey.GamepadL1),
+        (g => g.rightShoulder,      LKey.GamepadR1),
+        (g => g.leftTrigger,        LKey.GamepadL2),
+        (g => g.rightTrigger,       LKey.GamepadR2),
+        (g => g.leftStickButton,    LKey.GamepadL3),
+        (g => g.rightStickButton,   LKey.GamepadR3),
+        (g => g.startButton,        LKey.GamepadStart),
+        (g => g.selectButton,       LKey.GamepadSelect),
+        (g => g.dpad.up,            LKey.GamepadUp),
+        (g => g.dpad.down,          LKey.GamepadDown),
+        (g => g.dpad.left,          LKey.GamepadLeft),
+        (g => g.dpad.right,         LKey.GamepadRight),
+    };
 
 
     private void Start()
@@ -81,7 +102,8 @@ internal class LKeyInputAcquirer : MonoBehaviour
         upThisFrame.Clear();
         tmpKeyCode = KeyCode.None;
 
-        // Safety net: check if any keys are physically pressed
+        // Safety net: check if any keyboard keys are physically pressed
+        // Only clears keyboard-related keys, not gamepad keys
         if (Keyboard.current != null)
         {
             bool anyPressed = false;
@@ -95,13 +117,47 @@ internal class LKeyInputAcquirer : MonoBehaviour
                     }
                 }
                 catch {}
-            
 
             if (!anyPressed)
             {
-                pressedKeys.Clear();
+                var toRemove = new List<LKey>();
+                foreach (var key in pressedKeys)
+                    if ((int)key < 1101) // only remove non-gamepad keys
+                        toRemove.Add(key);
+                foreach (var key in toRemove)
+                    pressedKeys.Remove(key);
                 keyMemory.Clear();
             }
+        }
+
+        // Gamepad polling
+        var gamepad = Gamepad.current;
+        if (gamepad != null)
+        {
+            foreach (var (getControl, lkey) in GamepadBindings)
+            {
+                try
+                {
+                    var control = getControl(gamepad);
+                    if (control.wasPressedThisFrame)
+                    {
+                        pressedKeys.Add(lkey);
+                        downThisFrame.Add(lkey);
+                    }
+                    else if (control.wasReleasedThisFrame)
+                    {
+                        pressedKeys.Remove(lkey);
+                        upThisFrame.Add(lkey);
+                    }
+                }
+                catch {}
+            }
+        }
+        else
+        {
+            // No gamepad connected — clear any stale gamepad keys
+            foreach (var (_, lkey) in GamepadBindings)
+                pressedKeys.Remove(lkey);
         }
     }
 

--- a/Essentials/Enums/LKey.cs
+++ b/Essentials/Enums/LKey.cs
@@ -60,6 +60,13 @@ public enum LKey
     П = 917, Р = 918, С = 919, Т = 920, У = 921, Ф = 922, Х = 923, Ц = 924,
     Ч = 925, Ш = 926, Щ = 927, Ъ = 928, Ы = 929, Ь = 930, Э = 931, Ю = 932, Я = 933,
 
+    // Gamepad
+    GamepadSouth = 1101, GamepadNorth = 1102, GamepadEast = 1103, GamepadWest = 1104,
+    GamepadL1 = 1105, GamepadR1 = 1106, GamepadL2 = 1107, GamepadR2 = 1108,
+    GamepadL3 = 1109, GamepadR3 = 1110,
+    GamepadStart = 1111, GamepadSelect = 1112,
+    GamepadUp = 1113, GamepadDown = 1114, GamepadLeft = 1115, GamepadRight = 1116,
+
     // Hiragana 
     //The fallback font doesn't support it :/
     /*あ = 1001, い = 1002, う = 1003, え = 1004, お = 1005,


### PR DESCRIPTION
Adds gamepad button support to LKey and LKeyInputAcquirer, allowing mod authors to bind gamepad buttons in the Starlight config menu just like keyboard keys.

Changes:
- Added 16 gamepad values to LKey: face buttons (GamepadSouth/North/East/West), shoulders (GamepadL1/R1), triggers (GamepadL2/R2), stick clicks (GamepadL3/R3), GamepadStart/Select, and dpad directions (GamepadUp/Down/Left/Right)
- Extended LKeyInputAcquirer to poll Gamepad.current each frame in LateUpdate, tracking pressed/down/up state for all gamepad buttons
- Fixed the keyboard safety net to only clear keyboard-related LKey values, leaving gamepad keys unaffected (previously holding a gamepad button with no keyboard input caused it to be cleared every frame)

Tested in-game on Steam Deck with built-in gamepad. Verified hold, press, and release all behave correctly. Existing keyboard binding is unaffected.